### PR TITLE
(CEM-5346) Update to support the use of new private gem repo

### DIFF
--- a/.github/workflows/puppet_module_dep_checker.yml
+++ b/.github/workflows/puppet_module_dep_checker.yml
@@ -11,14 +11,19 @@ on:
         description: 'Puppet Ruby version (2.7, 3.2, etc.)'
         required: true
         type: string
+    secrets:
+      forge_token:
+        required: true
 
 jobs:
   puppet_module_dep_checker:
     runs-on: ubuntu-20.04
     env:
       PUPPET_GEM_VERSION: "~> ${{ inputs.puppet_major_version }}"
-      FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'
+      PUPPET_AUTH_TOKEN: ${{ secrets.forge_token }}
+      BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.forge_token }}"
       CEM_LINUX_NO_AUGEAS: 'true'
+
     steps:
       - name: "Checkout Source"
         uses: actions/checkout@v4

--- a/.github/workflows/reference_gen_test.yml
+++ b/.github/workflows/reference_gen_test.yml
@@ -2,10 +2,17 @@ name: "REFERENCE.md Generation Test"
 
 on:
   workflow_call:
+    secrets:
+      forge_token:
+        required: true
 
 jobs:
   reference_gen_test:
     runs-on: ubuntu-20.04
+    env:
+      PUPPET_AUTH_TOKEN: ${{ secrets.forge_token }}
+      BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.forge_token }}"
+
     steps:
       - name: "Checkout Source"
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit updates the two workflows that may need the auth token for downloading the gems that are now in Puppet private repo. These changes will need to reflect with the way they are being called in the sce modules. It's pretty much ensure that the token is being pass through.